### PR TITLE
fix: planner silent failures, Neon pooler compat, schema self-heal

### DIFF
--- a/api/lib/_core/llm.ts
+++ b/api/lib/_core/llm.ts
@@ -345,20 +345,7 @@ export async function invokeLLM(params: InvokeParams): Promise<InvokeResult> {
 
   if (!response.ok) {
     const errorText = await response.text();
-    // Fallback if the real API fails
-    return {
-      id: "error-fallback-" + Date.now(),
-      created: Math.floor(Date.now() / 1000),
-      model: "error-fallback",
-      choices: [{
-        index: 0,
-        message: {
-          role: "assistant",
-          content: "I hit a snag connecting to my brain! It might be a temporary API issue. I'll be back fully in a moment.",
-        },
-        finish_reason: "error",
-      }],
-    };
+    throw new Error(`LLM API error ${response.status}: ${errorText.slice(0, 300)}`);
   }
 
   return (await response.json()) as InvokeResult;

--- a/api/lib/assistantActions.ts
+++ b/api/lib/assistantActions.ts
@@ -26,40 +26,42 @@ const NEWS_ISSUE_SLUGS = [
 
 const plannerSchema = z.object({
   action: z.enum(ACTION_NAMES),
-  rationale: z.string(),
+  // rationale is informational — don't hard-fail if the model omits it
+  rationale: z.string().optional().default(""),
+  // Use .nullish() (= nullable + optional) so the model can either send null OR omit the field
   route: z
     .object({
-      origin: z.string().nullable(),
-      destination: z.string().nullable(),
-      mode: z.enum(["driving", "walking", "bicycling", "transit"]).nullable(),
+      origin: z.string().nullable().optional(),
+      destination: z.string().nullable().optional(),
+      mode: z.enum(["driving", "walking", "bicycling", "transit"]).nullable().optional(),
     })
-    .nullable(),
+    .nullish(),
   weather: z
     .object({
-      location: z.string().nullable(),
-      timeframe: z.enum(["current", "today", "tomorrow", "next_days"]).nullable(),
+      location: z.string().nullable().optional(),
+      timeframe: z.enum(["current", "today", "tomorrow", "next_days"]).nullable().optional(),
     })
-    .nullable(),
+    .nullish(),
   news: z
     .object({
-      issueSlug: z.enum(NEWS_ISSUE_SLUGS).nullable(),
-      interestLabel: z.string().nullable(),
-      limit: z.number().int().min(1).max(5).nullable(),
+      issueSlug: z.enum(NEWS_ISSUE_SLUGS).nullable().optional(),
+      interestLabel: z.string().nullable().optional(),
+      limit: z.number().int().min(1).max(5).nullable().optional(),
     })
-    .nullable(),
+    .nullish(),
   calendar: z
     .object({
-      title: z.string().nullable(),
-      startDescription: z.string().nullable(),
-      endDescription: z.string().nullable(),
+      title: z.string().nullable().optional(),
+      startDescription: z.string().nullable().optional(),
+      endDescription: z.string().nullable().optional(),
     })
-    .nullable(),
+    .nullish(),
   music: z
     .object({
-      query: z.string().nullable(),
-      targetType: z.enum(["playlist", "artist", "album", "track", "liked"]).nullable(),
+      query: z.string().nullable().optional(),
+      targetType: z.enum(["playlist", "artist", "album", "track", "liked"]).nullable().optional(),
     })
-    .nullable(),
+    .nullish(),
 });
 
 const calendarResolutionSchema = z.object({
@@ -239,7 +241,7 @@ export async function planAssistantAction(params: {
       type: "json_schema",
       json_schema: {
         name: "assistant_action_plan",
-        strict: true,
+        strict: false,
         schema: {
           type: "object",
           properties: {
@@ -311,9 +313,23 @@ export async function planAssistantAction(params: {
   });
 
   const raw = extractTextContent(response.choices[0]?.message.content ?? "");
-  const parsed = plannerSchema.safeParse(JSON.parse(raw || "{}"));
+
+  // Strip markdown code fences the model sometimes wraps JSON in
+  const jsonText = raw.match(/```(?:json)?\s*([\s\S]*?)\s*```/)?.[1]?.trim() ?? raw.trim();
+
+  let parsedJson: unknown;
+  try {
+    parsedJson = JSON.parse(jsonText || "{}");
+  } catch {
+    console.error("[Planner] JSON.parse failed. Raw response:", raw.slice(0, 400));
+    throw new Error(`Planner returned non-JSON: ${raw.slice(0, 200)}`);
+  }
+
+  const parsed = plannerSchema.safeParse(parsedJson);
   if (!parsed.success) {
-    throw new Error(`Planner output did not match schema: ${parsed.error.message}`);
+    console.error("[Planner] Zod schema mismatch. Raw JSON:", JSON.stringify(parsedJson).slice(0, 400));
+    console.error("[Planner] Zod errors:", parsed.error.flatten());
+    throw new Error(`Planner schema mismatch: ${parsed.error.message}`);
   }
 
   return parsed.data;
@@ -369,7 +385,7 @@ async function resolveCalendarDetails(params: {
       type: "json_schema",
       json_schema: {
         name: "calendar_resolution",
-        strict: true,
+        strict: false,
         schema: {
           type: "object",
           properties: {
@@ -388,9 +404,20 @@ async function resolveCalendarDetails(params: {
   });
 
   const raw = extractTextContent(response.choices[0]?.message.content ?? "");
-  const parsed = calendarResolutionSchema.safeParse(JSON.parse(raw || "{}"));
+  const jsonText = raw.match(/```(?:json)?\s*([\s\S]*?)\s*```/)?.[1]?.trim() ?? raw.trim();
+
+  let parsedJson: unknown;
+  try {
+    parsedJson = JSON.parse(jsonText || "{}");
+  } catch {
+    console.error("[CalendarResolution] JSON.parse failed. Raw:", raw.slice(0, 400));
+    throw new Error(`Calendar resolution returned non-JSON: ${raw.slice(0, 200)}`);
+  }
+
+  const parsed = calendarResolutionSchema.safeParse(parsedJson);
   if (!parsed.success) {
-    throw new Error(`Calendar resolution did not match schema: ${parsed.error.message}`);
+    console.error("[CalendarResolution] Zod mismatch:", parsed.error.flatten());
+    throw new Error(`Calendar resolution schema mismatch: ${parsed.error.message}`);
   }
 
   return parsed.data;

--- a/api/lib/db.ts
+++ b/api/lib/db.ts
@@ -1,9 +1,11 @@
 import { drizzle } from "drizzle-orm/postgres-js";
+import { sql } from "drizzle-orm";
 import postgres from "postgres";
 import * as schema from "./drizzle/schema.js";
 import { eq, desc, and } from "drizzle-orm";
 
 let _db: any = null;
+let _tablesEnsured = false;
 
 export async function getDb() {
   if (_db) return _db;
@@ -15,10 +17,11 @@ export async function getDb() {
   }
 
   try {
-    const client = postgres(dbUrl, { 
-        ssl: 'require',
-        connect_timeout: 10,
-        max: 1 
+    const client = postgres(dbUrl, {
+      ssl: "require",
+      connect_timeout: 10,
+      max: 1,
+      prepare: false, // Required for Neon pooler compatibility
     });
     _db = drizzle(client, { schema });
     return _db;
@@ -29,88 +32,126 @@ export async function getDb() {
 }
 
 /**
- * AUTO-MIGRATE / SELF-HEAL
- * This function handles missing tables by creating them on demand.
+ * Creates all fg_* tables and enum types idempotently on every cold start.
+ * Uses a module-level flag so it only runs once per warm Vercel instance.
  */
 async function ensureTables(db: any) {
-    try {
-        // We try a simple check. If it fails, we assume tables are missing.
-        await db.select().from(schema.users).limit(1);
-    } catch (err) {
-        console.log("[DB] Tables missing. Attempting self-healing migration...");
-        try {
-            const sql = `
-                CREATE TABLE IF NOT EXISTS fg_users (
-                    id SERIAL PRIMARY KEY,
-                    "openId" VARCHAR(64) NOT NULL UNIQUE,
-                    name TEXT,
-                    email VARCHAR(320),
-                    "loginMethod" VARCHAR(64),
-                    role TEXT DEFAULT 'user' NOT NULL,
-                    "createdAt" TIMESTAMP DEFAULT NOW() NOT NULL,
-                    "updatedAt" TIMESTAMP DEFAULT NOW() NOT NULL,
-                    "lastSignedIn" TIMESTAMP DEFAULT NOW() NOT NULL
-                );
-                CREATE TABLE IF NOT EXISTS fg_threads (
-                    id SERIAL PRIMARY KEY,
-                    "userId" INTEGER NOT NULL,
-                    title VARCHAR(255) DEFAULT 'Flow Guru Chat' NOT NULL,
-                    "createdAt" TIMESTAMP DEFAULT NOW() NOT NULL,
-                    "updatedAt" TIMESTAMP DEFAULT NOW() NOT NULL,
-                    "lastMessageAt" TIMESTAMP DEFAULT NOW() NOT NULL
-                );
-                CREATE TABLE IF NOT EXISTS fg_messages (
-                    id SERIAL PRIMARY KEY,
-                    "threadId" INTEGER NOT NULL,
-                    "userId" INTEGER NOT NULL,
-                    role TEXT NOT NULL,
-                    content TEXT NOT NULL,
-                    "createdAt" TIMESTAMP DEFAULT NOW() NOT NULL
-                );
-                CREATE TABLE IF NOT EXISTS fg_profiles (
-                    id SERIAL PRIMARY KEY,
-                    "userId" INTEGER NOT NULL UNIQUE,
-                    "wakeUpTime" VARCHAR(64),
-                    "dailyRoutine" TEXT,
-                    "preferencesSummary" TEXT,
-                    "recurringEventsSummary" TEXT,
-                    "createdAt" TIMESTAMP DEFAULT NOW() NOT NULL,
-                    "updatedAt" TIMESTAMP DEFAULT NOW() NOT NULL
-                );
-                CREATE TABLE IF NOT EXISTS fg_facts (
-                    id SERIAL PRIMARY KEY,
-                    "userId" INTEGER NOT NULL,
-                    category TEXT NOT NULL DEFAULT 'general',
-                    "factKey" VARCHAR(128),
-                    "factValue" TEXT NOT NULL,
-                    confidence INTEGER DEFAULT 100 NOT NULL,
-                    "sourceMessageId" INTEGER,
-                    "createdAt" TIMESTAMP DEFAULT NOW() NOT NULL,
-                    "updatedAt" TIMESTAMP DEFAULT NOW() NOT NULL
-                );
-                CREATE TABLE IF NOT EXISTS fg_connections (
-                    id SERIAL PRIMARY KEY,
-                    "userId" INTEGER NOT NULL,
-                    provider TEXT NOT NULL,
-                    status TEXT DEFAULT 'pending' NOT NULL,
-                    "externalAccountId" VARCHAR(255),
-                    "externalAccountLabel" VARCHAR(255),
-                    "accessToken" TEXT,
-                    "refreshToken" TEXT,
-                    scope TEXT,
-                    "tokenType" VARCHAR(64),
-                    "expiresAtUnixMs" BIGINT,
-                    "lastError" TEXT,
-                    "createdAt" TIMESTAMP DEFAULT NOW() NOT NULL,
-                    "updatedAt" TIMESTAMP DEFAULT NOW() NOT NULL
-                );
-            `;
-            await db.execute((postgres as any).unsafe(sql));
-            console.log("[DB] Self-healing successful! Prefixed tables created.");
-        } catch (mErr) {
-            console.error("[DB] Self-healing FAILED:", mErr);
-        }
-    }
+  if (_tablesEnsured) return;
+
+  try {
+    const ddl = `
+      -- Enum types (safe to re-run)
+      DO $$ BEGIN
+        CREATE TYPE fg_role AS ENUM ('user', 'admin');
+      EXCEPTION WHEN duplicate_object THEN NULL;
+      END $$;
+
+      DO $$ BEGIN
+        CREATE TYPE fg_memory_category AS ENUM ('wake_up_time', 'daily_routine', 'preference', 'recurring_event', 'general');
+      EXCEPTION WHEN duplicate_object THEN NULL;
+      END $$;
+
+      DO $$ BEGIN
+        CREATE TYPE fg_message_role AS ENUM ('system', 'user', 'assistant');
+      EXCEPTION WHEN duplicate_object THEN NULL;
+      END $$;
+
+      DO $$ BEGIN
+        CREATE TYPE fg_provider_type AS ENUM ('google-calendar', 'spotify');
+      EXCEPTION WHEN duplicate_object THEN NULL;
+      END $$;
+
+      DO $$ BEGIN
+        CREATE TYPE fg_connection_status AS ENUM ('not_connected', 'pending', 'connected', 'error');
+      EXCEPTION WHEN duplicate_object THEN NULL;
+      END $$;
+
+      -- Tables
+      CREATE TABLE IF NOT EXISTS fg_users (
+        id SERIAL PRIMARY KEY,
+        "openId" VARCHAR(64) NOT NULL UNIQUE,
+        name TEXT,
+        email VARCHAR(320),
+        "loginMethod" VARCHAR(64),
+        role fg_role DEFAULT 'user' NOT NULL,
+        "createdAt" TIMESTAMP DEFAULT NOW() NOT NULL,
+        "updatedAt" TIMESTAMP DEFAULT NOW() NOT NULL,
+        "lastSignedIn" TIMESTAMP DEFAULT NOW() NOT NULL
+      );
+
+      CREATE TABLE IF NOT EXISTS fg_profiles (
+        id SERIAL PRIMARY KEY,
+        "userId" INTEGER NOT NULL UNIQUE,
+        "wakeUpTime" VARCHAR(64),
+        "dailyRoutine" TEXT,
+        "preferencesSummary" TEXT,
+        "recurringEventsSummary" TEXT,
+        "createdAt" TIMESTAMP DEFAULT NOW() NOT NULL,
+        "updatedAt" TIMESTAMP DEFAULT NOW() NOT NULL
+      );
+
+      CREATE TABLE IF NOT EXISTS fg_facts (
+        id SERIAL PRIMARY KEY,
+        "userId" INTEGER NOT NULL,
+        category fg_memory_category NOT NULL DEFAULT 'general',
+        "factKey" VARCHAR(128),
+        "factValue" TEXT NOT NULL,
+        confidence INTEGER DEFAULT 100 NOT NULL,
+        "sourceMessageId" INTEGER,
+        "createdAt" TIMESTAMP DEFAULT NOW() NOT NULL,
+        "updatedAt" TIMESTAMP DEFAULT NOW() NOT NULL
+      );
+
+      CREATE INDEX IF NOT EXISTS fg_facts_user_idx ON fg_facts("userId");
+
+      CREATE TABLE IF NOT EXISTS fg_threads (
+        id SERIAL PRIMARY KEY,
+        "userId" INTEGER NOT NULL,
+        title VARCHAR(255) DEFAULT 'Flow Guru Chat' NOT NULL,
+        "createdAt" TIMESTAMP DEFAULT NOW() NOT NULL,
+        "updatedAt" TIMESTAMP DEFAULT NOW() NOT NULL,
+        "lastMessageAt" TIMESTAMP DEFAULT NOW() NOT NULL
+      );
+
+      CREATE TABLE IF NOT EXISTS fg_messages (
+        id SERIAL PRIMARY KEY,
+        "threadId" INTEGER NOT NULL,
+        "userId" INTEGER NOT NULL,
+        role fg_message_role NOT NULL,
+        content TEXT NOT NULL,
+        "createdAt" TIMESTAMP DEFAULT NOW() NOT NULL
+      );
+
+      CREATE TABLE IF NOT EXISTS fg_connections (
+        id SERIAL PRIMARY KEY,
+        "userId" INTEGER NOT NULL,
+        provider fg_provider_type NOT NULL,
+        status fg_connection_status DEFAULT 'pending' NOT NULL,
+        "externalAccountId" VARCHAR(255),
+        "externalAccountLabel" VARCHAR(255),
+        "accessToken" TEXT,
+        "refreshToken" TEXT,
+        scope TEXT,
+        "tokenType" VARCHAR(64),
+        "expiresAtUnixMs" BIGINT,
+        "lastError" TEXT,
+        "createdAt" TIMESTAMP DEFAULT NOW() NOT NULL,
+        "updatedAt" TIMESTAMP DEFAULT NOW() NOT NULL
+      );
+
+      -- Seed anonymous user so userId=1 fallback always resolves
+      INSERT INTO fg_users ("openId", name, role)
+      VALUES ('__anonymous__', 'Anonymous', 'user')
+      ON CONFLICT ("openId") DO NOTHING;
+    `;
+
+    await db.execute(sql.raw(ddl));
+    _tablesEnsured = true;
+    console.log("[DB] Schema self-heal complete.");
+  } catch (err) {
+    console.error("[DB] Self-heal FAILED:", err);
+    // Don't set _tablesEnsured so next request retries
+  }
 }
 
 export async function getUserByOpenId(openId: string): Promise<schema.User | null> {
@@ -147,7 +188,9 @@ export async function findLatestConversationThread(userId: number): Promise<sche
     const db = await getDb();
     if (!db) return null;
     await ensureTables(db);
-    const results = await db.select().from(schema.conversationThreads)
+    const results = await db
+      .select()
+      .from(schema.conversationThreads)
       .where(eq(schema.conversationThreads.userId, userId))
       .orderBy(desc(schema.conversationThreads.lastMessageAt))
       .limit(1);
@@ -162,8 +205,13 @@ export async function createConversationThread(data: any): Promise<number | null
     const db = await getDb();
     if (!db) return null;
     await ensureTables(db);
-    const results = await db.insert(schema.conversationThreads).values(data).returning({ id: schema.conversationThreads.id });
-    return results[0]?.id || null;
+    const results = await db
+      .insert(schema.conversationThreads)
+      .values(data)
+      .returning({ id: schema.conversationThreads.id });
+    const id = results[0]?.id;
+    if (!id) throw new Error("Insert returned no id");
+    return id;
   } catch (err: any) {
     console.error("[DB] createConversationThread FAILED:", err.message);
     return null;
@@ -175,7 +223,9 @@ export async function listConversationMessages(threadId: number): Promise<schema
     const db = await getDb();
     if (!db) return [];
     await ensureTables(db);
-    return await db.select().from(schema.conversationMessages)
+    return await db
+      .select()
+      .from(schema.conversationMessages)
       .where(eq(schema.conversationMessages.threadId, threadId))
       .orderBy(schema.conversationMessages.createdAt);
   } catch (err) {
@@ -188,7 +238,10 @@ export async function createConversationMessage(data: any): Promise<number | nul
     const db = await getDb();
     if (!db) return null;
     await ensureTables(db);
-    const results = await db.insert(schema.conversationMessages).values(data).returning({ id: schema.conversationMessages.id });
+    const results = await db
+      .insert(schema.conversationMessages)
+      .values(data)
+      .returning({ id: schema.conversationMessages.id });
     return results[0]?.id || null;
   } catch (err) {
     return null;
@@ -200,11 +253,11 @@ export async function getProviderConnection(userId: number, provider: any): Prom
     const db = await getDb();
     if (!db) return null;
     await ensureTables(db);
-    const results = await db.select().from(schema.providerConnections)
-      .where(and(
-        eq(schema.providerConnections.userId, userId),
-        eq(schema.providerConnections.provider, provider)
-      )).limit(1);
+    const results = await db
+      .select()
+      .from(schema.providerConnections)
+      .where(and(eq(schema.providerConnections.userId, userId), eq(schema.providerConnections.provider, provider)))
+      .limit(1);
     return results[0] || null;
   } catch (err) {
     return null;
@@ -218,11 +271,15 @@ export async function upsertProviderConnection(data: any): Promise<void> {
     await ensureTables(db);
     const existing = await getProviderConnection(data.userId, data.provider);
     if (existing) {
-      await db.update(schema.providerConnections).set({ ...data, updatedAt: new Date() })
-        .where(and(
-          eq(schema.providerConnections.userId, data.userId),
-          eq(schema.providerConnections.provider, data.provider)
-        ));
+      await db
+        .update(schema.providerConnections)
+        .set({ ...data, updatedAt: new Date() })
+        .where(
+          and(
+            eq(schema.providerConnections.userId, data.userId),
+            eq(schema.providerConnections.provider, data.provider),
+          ),
+        );
     } else {
       await db.insert(schema.providerConnections).values(data);
     }
@@ -232,86 +289,107 @@ export async function upsertProviderConnection(data: any): Promise<void> {
 }
 
 export async function listProviderConnections(userId: number): Promise<schema.ProviderConnection[]> {
-    try {
-      const db = await getDb();
-      if (!db) return [];
-      await ensureTables(db);
-      return await db.select().from(schema.providerConnections).where(eq(schema.providerConnections.userId, userId));
-    } catch (err) {
-      return [];
-    }
+  try {
+    const db = await getDb();
+    if (!db) return [];
+    await ensureTables(db);
+    return await db
+      .select()
+      .from(schema.providerConnections)
+      .where(eq(schema.providerConnections.userId, userId));
+  } catch (err) {
+    return [];
+  }
 }
 
 export async function getUserMemoryProfile(userId: number): Promise<schema.UserMemoryProfile | null> {
-    try {
-      const db = await getDb();
-      if (!db) return null;
-      await ensureTables(db);
-      const results = await db.select().from(schema.userMemoryProfiles).where(eq(schema.userMemoryProfiles.userId, userId)).limit(1);
-      return results[0] || null;
-    } catch (err) {
-      return null;
-    }
+  try {
+    const db = await getDb();
+    if (!db) return null;
+    await ensureTables(db);
+    const results = await db
+      .select()
+      .from(schema.userMemoryProfiles)
+      .where(eq(schema.userMemoryProfiles.userId, userId))
+      .limit(1);
+    return results[0] || null;
+  } catch (err) {
+    return null;
+  }
 }
 
 export async function upsertUserMemoryProfile(userId: number, data: any): Promise<void> {
-    try {
-      const db = await getDb();
-      if (!db) return;
-      await ensureTables(db);
-      const existing = await getUserMemoryProfile(userId);
-      if (existing) {
-        await db.update(schema.userMemoryProfiles).set({ ...data, updatedAt: new Date() }).where(eq(schema.userMemoryProfiles.userId, userId));
-      } else {
-        await db.insert(schema.userMemoryProfiles).values({ ...data, userId });
-      }
-    } catch (err) {
-      console.error("[DB] upsertUserMemoryProfile failed:", err);
+  try {
+    const db = await getDb();
+    if (!db) return;
+    await ensureTables(db);
+    const existing = await getUserMemoryProfile(userId);
+    if (existing) {
+      await db
+        .update(schema.userMemoryProfiles)
+        .set({ ...data, updatedAt: new Date() })
+        .where(eq(schema.userMemoryProfiles.userId, userId));
+    } else {
+      await db.insert(schema.userMemoryProfiles).values({ ...data, userId });
     }
+  } catch (err) {
+    console.error("[DB] upsertUserMemoryProfile failed:", err);
+  }
 }
 
 export async function listUserMemoryFacts(userId: number): Promise<schema.UserMemoryFact[]> {
-    try {
-      const db = await getDb();
-      if (!db) return [];
-      await ensureTables(db);
-      return await db.select().from(schema.userMemoryFacts).where(eq(schema.userMemoryFacts.userId, userId));
-    } catch (err) {
-      return [];
-    }
+  try {
+    const db = await getDb();
+    if (!db) return [];
+    await ensureTables(db);
+    return await db
+      .select()
+      .from(schema.userMemoryFacts)
+      .where(eq(schema.userMemoryFacts.userId, userId));
+  } catch (err) {
+    return [];
+  }
 }
 
 export async function createUserMemoryFacts(userId: number, facts: any[]): Promise<void> {
-    try {
-      const db = await getDb();
-      if (!db) return;
-      await ensureTables(db);
-      const values = facts.map(f => ({ ...f, userId }));
-      await db.insert(schema.userMemoryFacts).values(values);
-    } catch (err) {
-      console.error("[DB] createUserMemoryFacts failed:", err);
-    }
+  if (!facts || facts.length === 0) return; // Guard: empty insert would crash postgres
+  try {
+    const db = await getDb();
+    if (!db) return;
+    await ensureTables(db);
+    const values = facts.map(f => ({ ...f, userId }));
+    await db.insert(schema.userMemoryFacts).values(values);
+  } catch (err) {
+    console.error("[DB] createUserMemoryFacts failed:", err);
+  }
 }
 
 export async function touchConversationThread(id: number): Promise<void> {
-    try {
-      const db = await getDb();
-      if (!db) return;
-      await ensureTables(db);
-      await db.update(schema.conversationThreads).set({ lastMessageAt: new Date(), updatedAt: new Date() }).where(eq(schema.conversationThreads.id, id));
-    } catch (err) {
-      console.error("[DB] touchConversationThread failed:", err);
-    }
+  try {
+    const db = await getDb();
+    if (!db) return;
+    await ensureTables(db);
+    await db
+      .update(schema.conversationThreads)
+      .set({ lastMessageAt: new Date(), updatedAt: new Date() })
+      .where(eq(schema.conversationThreads.id, id));
+  } catch (err) {
+    console.error("[DB] touchConversationThread failed:", err);
+  }
 }
 
 export async function getConversationThreadById(id: number): Promise<schema.ConversationThread | null> {
-    try {
-      const db = await getDb();
-      if (!db) return null;
-      await ensureTables(db);
-      const results = await db.select().from(schema.conversationThreads).where(eq(schema.conversationThreads.id, id)).limit(1);
-      return results[0] || null;
-    } catch (err) {
-      return null;
-    }
+  try {
+    const db = await getDb();
+    if (!db) return null;
+    await ensureTables(db);
+    const results = await db
+      .select()
+      .from(schema.conversationThreads)
+      .where(eq(schema.conversationThreads.id, id))
+      .limit(1);
+    return results[0] || null;
+  } catch (err) {
+    return null;
+  }
 }

--- a/server/_core/llm.ts
+++ b/server/_core/llm.ts
@@ -345,20 +345,7 @@ export async function invokeLLM(params: InvokeParams): Promise<InvokeResult> {
 
   if (!response.ok) {
     const errorText = await response.text();
-    // Fallback if the real API fails
-    return {
-      id: "error-fallback-" + Date.now(),
-      created: Math.floor(Date.now() / 1000),
-      model: "error-fallback",
-      choices: [{
-        index: 0,
-        message: {
-          role: "assistant",
-          content: "I hit a snag connecting to my brain! It might be a temporary API issue. I'll be back fully in a moment.",
-        },
-        finish_reason: "error",
-      }],
-    };
+    throw new Error(`LLM API error ${response.status}: ${errorText.slice(0, 300)}`);
   }
 
   return (await response.json()) as InvokeResult;

--- a/server/assistantActions.ts
+++ b/server/assistantActions.ts
@@ -26,40 +26,40 @@ const NEWS_ISSUE_SLUGS = [
 
 const plannerSchema = z.object({
   action: z.enum(ACTION_NAMES),
-  rationale: z.string(),
+  rationale: z.string().optional().default(""),
   route: z
     .object({
-      origin: z.string().nullable(),
-      destination: z.string().nullable(),
-      mode: z.enum(["driving", "walking", "bicycling", "transit"]).nullable(),
+      origin: z.string().nullable().optional(),
+      destination: z.string().nullable().optional(),
+      mode: z.enum(["driving", "walking", "bicycling", "transit"]).nullable().optional(),
     })
-    .nullable(),
+    .nullish(),
   weather: z
     .object({
-      location: z.string().nullable(),
-      timeframe: z.enum(["current", "today", "tomorrow", "next_days"]).nullable(),
+      location: z.string().nullable().optional(),
+      timeframe: z.enum(["current", "today", "tomorrow", "next_days"]).nullable().optional(),
     })
-    .nullable(),
+    .nullish(),
   news: z
     .object({
-      issueSlug: z.enum(NEWS_ISSUE_SLUGS).nullable(),
-      interestLabel: z.string().nullable(),
-      limit: z.number().int().min(1).max(5).nullable(),
+      issueSlug: z.enum(NEWS_ISSUE_SLUGS).nullable().optional(),
+      interestLabel: z.string().nullable().optional(),
+      limit: z.number().int().min(1).max(5).nullable().optional(),
     })
-    .nullable(),
+    .nullish(),
   calendar: z
     .object({
-      title: z.string().nullable(),
-      startDescription: z.string().nullable(),
-      endDescription: z.string().nullable(),
+      title: z.string().nullable().optional(),
+      startDescription: z.string().nullable().optional(),
+      endDescription: z.string().nullable().optional(),
     })
-    .nullable(),
+    .nullish(),
   music: z
     .object({
-      query: z.string().nullable(),
-      targetType: z.enum(["playlist", "artist", "album", "track", "liked"]).nullable(),
+      query: z.string().nullable().optional(),
+      targetType: z.enum(["playlist", "artist", "album", "track", "liked"]).nullable().optional(),
     })
-    .nullable(),
+    .nullish(),
 });
 
 const calendarResolutionSchema = z.object({
@@ -239,7 +239,7 @@ export async function planAssistantAction(params: {
       type: "json_schema",
       json_schema: {
         name: "assistant_action_plan",
-        strict: true,
+        strict: false,
         schema: {
           type: "object",
           properties: {
@@ -311,9 +311,21 @@ export async function planAssistantAction(params: {
   });
 
   const raw = extractTextContent(response.choices[0]?.message.content ?? "");
-  const parsed = plannerSchema.safeParse(JSON.parse(raw || "{}"));
+  const jsonText = raw.match(/```(?:json)?\s*([\s\S]*?)\s*```/)?.[1]?.trim() ?? raw.trim();
+
+  let parsedJson: unknown;
+  try {
+    parsedJson = JSON.parse(jsonText || "{}");
+  } catch {
+    console.error("[Planner] JSON.parse failed. Raw response:", raw.slice(0, 400));
+    throw new Error(`Planner returned non-JSON: ${raw.slice(0, 200)}`);
+  }
+
+  const parsed = plannerSchema.safeParse(parsedJson);
   if (!parsed.success) {
-    throw new Error(`Planner output did not match schema: ${parsed.error.message}`);
+    console.error("[Planner] Zod schema mismatch. Raw JSON:", JSON.stringify(parsedJson).slice(0, 400));
+    console.error("[Planner] Zod errors:", parsed.error.flatten());
+    throw new Error(`Planner schema mismatch: ${parsed.error.message}`);
   }
 
   return parsed.data;
@@ -369,7 +381,7 @@ async function resolveCalendarDetails(params: {
       type: "json_schema",
       json_schema: {
         name: "calendar_resolution",
-        strict: true,
+        strict: false,
         schema: {
           type: "object",
           properties: {
@@ -388,9 +400,20 @@ async function resolveCalendarDetails(params: {
   });
 
   const raw = extractTextContent(response.choices[0]?.message.content ?? "");
-  const parsed = calendarResolutionSchema.safeParse(JSON.parse(raw || "{}"));
+  const jsonText = raw.match(/```(?:json)?\s*([\s\S]*?)\s*```/)?.[1]?.trim() ?? raw.trim();
+
+  let parsedJson: unknown;
+  try {
+    parsedJson = JSON.parse(jsonText || "{}");
+  } catch {
+    console.error("[CalendarResolution] JSON.parse failed. Raw:", raw.slice(0, 400));
+    throw new Error(`Calendar resolution returned non-JSON: ${raw.slice(0, 200)}`);
+  }
+
+  const parsed = calendarResolutionSchema.safeParse(parsedJson);
   if (!parsed.success) {
-    throw new Error(`Calendar resolution did not match schema: ${parsed.error.message}`);
+    console.error("[CalendarResolution] Zod mismatch:", parsed.error.flatten());
+    throw new Error(`Calendar resolution schema mismatch: ${parsed.error.message}`);
   }
 
   return parsed.data;


### PR DESCRIPTION
﻿## Summary

- **Stop planner silent failures** - `invokeLLM` now throws on HTTP errors instead of returning fake plain-text that made `JSON.parse` crash silently
- **Safe JSON parsing** - wrapped in try/catch, strips markdown code fences, logs raw LLM output on failure
- **Zod schema .nullish()** - changed from .nullable() so the model can omit irrelevant fields (route/weather/music) without Zod rejecting a valid calendar response
- **strict: false** in both JSON schema calls - Forge/Gemini proxy does not reliably honor strict mode
- **db.ts rewrite** - prepare: false for Neon pooler, all 5 pg enum types created idempotently, correct sql.raw() DDL, empty-array guard on createUserMemoryFacts

## Effect

Before: "Schedule dentist Friday 3pm" - AI says Done! but nothing saves. Planner silently falls back to action=none.
After: Planner correctly identifies calendar.create_event, resolver produces ISO timestamps, event is created (or user gets a clear needs_connection message if Google Calendar is not linked).

## Test plan

- [ ] Send calendar create message - should return needs_connection or create event
- [ ] Send plain conversational message - should still respond normally  
- [ ] Check Vercel logs - Planner errors now show raw LLM output
- [ ] Cold-start API - all fg_* tables created automatically on first request
