### PR TITLE
fix(chat): import sql from drizzle-orm

### DIFF
--- a/api/chat.ts
+++ b/api/chat.ts
@@ -1,7 +1,7 @@
 import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
 import { streamText, tool, convertToModelMessages, stepCountIs, type UIMessage } from 'ai';
 import { z } from 'zod';
-import { and, eq, ilike, desc } from 'drizzle-orm';
+import { and, eq, ilike, desc, sql } from 'drizzle-orm';
 import { db } from './lib/db.js';
 import { userFacts } from './lib/drizzle/schema.js';
 


### PR DESCRIPTION
Addresses Copilot review on #24:

- Import `sql` from drizzle-orm in api/chat.ts (it was used in the route but never imported, would throw at runtime).

Follow-up still needed (not in this PR): add `CREATE EXTENSION pg_trgm` + `user_facts` table + indexes to FLOW_GURU_DDL in api/lib/db.ts so the self-heal logic provisions them automatically. For now, run that DDL once manually on Neon.