### PR TITLE
fix(schema): add sql/uuid imports; remove stray q chars

### DIFF
--- a/api/lib/drizzle/schema.ts
+++ b/api/lib/drizzle/schema.ts
@@ -1,4 +1,5 @@
-import { pgTable, serial, text, varchar, timestamp, pgEnum, integer, index, bigint } from "drizzle-orm/pg-core";
+import { pgTable, serial, text, varchar, timestamp, pgEnum, integer, index, bigint, uuid } from "drizzle-orm/pg-core";
+import { sql } from "drizzle-orm";
 
 // Enums with unique names to avoid collisions in shared DB
 export const roleEnum = pgEnum("fg_role", ["user", "admin"]);
@@ -172,11 +173,11 @@ export const localEvents = pgTable(
 
 export type LocalEvent = typeof localEvents.$inferSelect;
 export type InsertLocalEvent = typeof localEvents.$inferInsert;
-q
 
 
-q
-q
+
+
+
 
 
 // === Chat memory (added by feat/chat-memory-neon) ===


### PR DESCRIPTION
Addresses Gemini code review on the closed #25.

Fixes runtime/build errors in `api/lib/drizzle/schema.ts`:
- Add missing `uuid` import to the existing `drizzle-orm/pg-core` import (used on line ~185 in `userFacts.id`).
- Add new `import { sql } from "drizzle-orm"` (used on line ~192 for the `pg_trgm` GIN index expression).
- Remove three stray `q` characters that were accidentally inserted between `localEvents` types and the `userFacts` table.

Follow-up still pending: add `CREATE EXTENSION pg_trgm` + `user_facts` table to FLOW_GURU_DDL in `api/lib/db.ts` so self-heal provisions them; until then run that DDL once on Neon manually.