### PR TITLE
fix(chat): consolidate memory on fg_facts, resolve userId via openId

### DIFF
--- a/api/chat.ts
+++ b/api/chat.ts
@@ -2,8 +2,8 @@ import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
 import { streamText, tool, convertToModelMessages, stepCountIs, type UIMessage } from 'ai';
 import { z } from 'zod';
 import { and, eq, ilike, desc } from 'drizzle-orm';
-import { db } from './lib/db.js';
-import { userFacts } from './lib/drizzle/schema.js';
+import { getDb, getUserByOpenId, getOrCreateAnonymousUser } from './lib/db.js';
+import { userMemoryFacts } from './lib/drizzle/schema.js';
 
 export const config = { maxDuration: 60 };
 
@@ -13,23 +13,39 @@ const deepseek = createOpenAICompatible({
   apiKey: process.env.DEEPSEEK_API_KEY!,
 });
 
+const ANONYMOUS_OPEN_ID = '__flow_guru_anonymous__';
+
 export default async function handler(req: Request) {
   if (req.method !== 'POST') {
     return new Response('Method Not Allowed', { status: 405 });
   }
 
   try {
-    const body = (await req.json()) as { messages: UIMessage[]; userId?: string };
-    const { messages, userId = 'anonymous' } = body;
+    const body = (await req.json()) as {
+      messages: UIMessage[];
+      openId?: string;
+      userId?: string;
+    };
+    const openId = body.openId ?? body.userId ?? ANONYMOUS_OPEN_ID;
 
-    const modelMessages = await convertToModelMessages(messages);
+    const user =
+      (await getUserByOpenId(openId)) ??
+      (await getOrCreateAnonymousUser());
+    const userIdInt = user.id;
+
+    const db = await getDb();
+    if (!db) {
+      throw new Error('Database unavailable');
+    }
+
+    const modelMessages = await convertToModelMessages(body.messages);
 
     const result = streamText({
       model: deepseek('deepseek-chat'),
-      system: `You are Flow Guru, a concise voice-first personal assistant for ${userId}.
+      system: `You are Flow Guru, a concise voice-first personal assistant.
 Keep responses brief and conversational — they will be spoken aloud.
 Use recallMemory before answering personal questions.
-Use saveMemory when the user shares a fact about themselves.`,
+Use saveMemory when the user shares a fact about themselves (preferences, routine, health, work, hobbies, pets, etc.).`,
       messages: modelMessages,
       stopWhen: stepCountIs(5),
       tools: {
@@ -39,13 +55,16 @@ Use saveMemory when the user shares a fact about themselves.`,
           execute: async ({ query }) => {
             const rows = await db
               .select({
-                fact: userFacts.fact,
-                category: userFacts.category,
-                createdAt: userFacts.createdAt,
+                fact: userMemoryFacts.factValue,
+                category: userMemoryFacts.category,
+                createdAt: userMemoryFacts.createdAt,
               })
-              .from(userFacts)
-              .where(and(eq(userFacts.userId, userId), ilike(userFacts.fact, `%${query}%`)))
-              .orderBy(desc(userFacts.createdAt))
+              .from(userMemoryFacts)
+              .where(and(
+                eq(userMemoryFacts.userId, userIdInt),
+                ilike(userMemoryFacts.factValue, `%${query}%`),
+              ))
+              .orderBy(desc(userMemoryFacts.createdAt))
               .limit(5);
             return rows;
           },
@@ -54,14 +73,21 @@ Use saveMemory when the user shares a fact about themselves.`,
           description: 'Persist a fact about the user',
           inputSchema: z.object({
             fact: z.string(),
-            category: z.enum(['preference', 'personal', 'work', 'health', 'general']),
+            category: z.enum(['wake_up_time', 'daily_routine', 'preference', 'recurring_event', 'general']),
+            factKey: z.string().optional(),
           }),
-          execute: async ({ fact, category }) => {
+          execute: async ({ fact, category, factKey }) => {
             try {
-              await db.insert(userFacts).values({ userId, fact, category });
+              await db.insert(userMemoryFacts).values({
+                userId: userIdInt,
+                factValue: fact,
+                category,
+                factKey: factKey ?? null,
+              });
               return { saved: true };
             } catch (err) {
-              return { saved: false, error: (err as Error).message };
+              console.error('saveMemory failed', err);
+              return { saved: false, error: String(err) };
             }
           },
         }),
@@ -70,10 +96,10 @@ Use saveMemory when the user shares a fact about themselves.`,
 
     return result.toUIMessageStreamResponse();
   } catch (err) {
-    console.error('[api/chat] error:', err);
-    return new Response(JSON.stringify({ error: 'Chat failed' }), {
+    console.error('chat handler error', err);
+    return new Response(JSON.stringify({ error: String(err) }), {
       status: 500,
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'content-type': 'application/json' },
     });
   }
 }

--- a/api/lib/drizzle/schema.ts
+++ b/api/lib/drizzle/schema.ts
@@ -1,5 +1,4 @@
-import { pgTable, serial, text, varchar, timestamp, pgEnum, integer, index, bigint, uuid } from "drizzle-orm/pg-core";
-import { sql } from "drizzle-orm";
+import { pgTable, serial, text, varchar, timestamp, pgEnum, integer, index, bigint } from "drizzle-orm/pg-core";
 
 // Enums with unique names to avoid collisions in shared DB
 export const roleEnum = pgEnum("fg_role", ["user", "admin"]);
@@ -173,21 +172,3 @@ export const localEvents = pgTable(
 
 export type LocalEvent = typeof localEvents.$inferSelect;
 export type InsertLocalEvent = typeof localEvents.$inferInsert;
-
-
-
-
-
-
-
-// === Chat memory (added by feat/chat-memory-neon) ===
-export const userFacts = pgTable("user_facts", {
-  id: uuid("id").defaultRandom().primaryKey(),
-  userId: text("user_id").notNull(),
-  fact: text("fact").notNull(),
-  category: text("category").notNull().default("general"),
-  createdAt: timestamp("created_at").defaultNow().notNull(),
-}, (t) => ({
-  userIdIdx: index("user_facts_user_id_idx").on(t.userId),
-  factTrgmIdx: index("user_facts_fact_trgm_idx").using("gin", sql`${t.fact} gin_trgm_ops`),
-}));

--- a/drizzle/0004_drop_orphan_memory_tables.sql
+++ b/drizzle/0004_drop_orphan_memory_tables.sql
@@ -1,0 +1,3 @@
+DROP TABLE IF EXISTS user_facts CASCADE;
+DROP TABLE IF EXISTS chat_messages CASCADE;
+DROP TABLE IF EXISTS rate_limit_events CASCADE;


### PR DESCRIPTION
The chat memory tools were writing to a parallel orphan user_facts table that no other code reads. Switch them to userMemoryFacts (fg_facts), the canonical table used by api/lib/db.ts. Resolve string openId to integer fg_users.id via getUserByOpenId/getOrCreateAnonymousUser.

Also drops 3 unused tables (user_facts, chat_messages, rate_limit_events) created during the Neon-port exploration.

Bug impact: every saveMemory call since the Neon port persisted to a table the rest of the app never queries. Memory was effectively broken across sessions.

Made-with: Cursor