### PR TITLE
feat(chat): add list tools (get_all/get_items/add/complete) and routi…

### DIFF
--- a/api/chat.ts
+++ b/api/chat.ts
@@ -170,7 +170,7 @@ NEVER:
             const list = await findListByName(dbUserId, listName);
             if (!list) return { error: `No list named "${listName}".` };
             const items = await getListItems(dbUserId, list.id);
-            const target = items.find(i => i.content.toLowerCase().includes(q.toLowerCase()));
+            const search = q.toLowerCase();         const target = items.find(i => i.completed === 0 && i.content.trim().toLowerCase() === search)           ?? items.find(i => i.completed === 0 && i.content.toLowerCase().includes(search));
             if (!target) return { error: `No item matching "${item}" on "${list.name}".` };
             await toggleListItem(dbUserId, target.id, true);
             return { ok: true };

--- a/api/chat.ts
+++ b/api/chat.ts
@@ -107,7 +107,9 @@ NEVER:
           description:
             "Read all items in a named list. Use when the user asks 'what's on my <X> list', " +
             "'show me my groceries', etc.",
-          inputSchema: z.object({ listName: z.string() }),
+          inputSchema: z.object({
+            listName: z.string().trim().min(1, 'listName required'),
+          }),
           execute: async ({ listName }) => {
             if (!dbUserId) return { error: 'Sign in to use lists.' };
             const list = await findListByName(dbUserId, listName);
@@ -131,8 +133,8 @@ NEVER:
             "If the list doesn't exist yet, this tool creates it. " +
             'NEVER use this for time-bound calendar events.',
           inputSchema: z.object({
-            listName: z.string().describe("e.g. 'grocery', 'todo', 'packing'"),
-            item: z.string().describe('the single item or task text'),
+            listName: z.string().trim().min(1, 'listName required').describe("e.g. 'grocery', 'todo', 'packing'"),
+            item: z.string().trim().min(1, 'item required').describe('the single item or task text'),
             reminderAtISO: z.string().optional(),
             locationTrigger: z.string().optional(),
           }),
@@ -157,13 +159,18 @@ NEVER:
         }),
         list_complete_item: tool({
           description: 'Mark an item on a named list as done.',
-          inputSchema: z.object({ listName: z.string(), item: z.string() }),
+          inputSchema: z.object({
+            listName: z.string().trim().min(1, 'listName required'),
+            item: z.string().trim().min(1, 'item required'),
+          }),
           execute: async ({ listName, item }) => {
             if (!dbUserId) return { error: 'Sign in to use lists.' };
+            const q = item.trim();
+            if (!q) return { error: 'Specify which item to complete.' };
             const list = await findListByName(dbUserId, listName);
             if (!list) return { error: `No list named "${listName}".` };
             const items = await getListItems(dbUserId, list.id);
-            const target = items.find(i => i.content.toLowerCase().includes(item.toLowerCase()));
+            const target = items.find(i => i.content.toLowerCase().includes(q.toLowerCase()));
             if (!target) return { error: `No item matching "${item}" on "${list.name}".` };
             await toggleListItem(dbUserId, target.id, true);
             return { ok: true };

--- a/api/chat.ts
+++ b/api/chat.ts
@@ -2,7 +2,18 @@ import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
 import { streamText, tool, convertToModelMessages, stepCountIs, type UIMessage } from 'ai';
 import { z } from 'zod';
 import { and, eq, ilike, desc } from 'drizzle-orm';
-import { getDb, getUserByOpenId, getOrCreateAnonymousUser } from './lib/db.js';
+import {
+  addListItem,
+  createList,
+  getDb,
+  getListItems,
+  getOrCreateAnonymousUser,
+  getUserByOpenId,
+  listUserLists,
+  setListItemLocationTrigger,
+  setListItemReminder,
+  toggleListItem,
+} from './lib/db.js';
 import { userMemoryFacts } from './lib/drizzle/schema.js';
 
 export const config = { maxDuration: 60 };
@@ -14,6 +25,14 @@ const deepseek = createOpenAICompatible({
 });
 
 const ANONYMOUS_OPEN_ID = '__flow_guru_anonymous__';
+
+async function findListByName(userId: number, name: string) {
+  const all = await listUserLists(userId);
+  const target = name.trim().toLowerCase();
+  return all.find(l => l.name.trim().toLowerCase() === target)
+    ?? all.find(l => l.name.trim().toLowerCase().includes(target))
+    ?? null;
+}
 
 export default async function handler(req: Request) {
   if (req.method !== 'POST') {
@@ -27,11 +46,13 @@ export default async function handler(req: Request) {
       userId?: string;
     };
     const openId = body.openId ?? body.userId ?? ANONYMOUS_OPEN_ID;
+    const isAnonymousRequest = openId === 'anonymous' || openId === ANONYMOUS_OPEN_ID;
 
     const user =
-      (await getUserByOpenId(openId)) ??
+      (!isAnonymousRequest ? await getUserByOpenId(openId) : null) ??
       (await getOrCreateAnonymousUser());
     const userIdInt = user.id;
+    const dbUserId = isAnonymousRequest || user.openId === ANONYMOUS_OPEN_ID ? null : user.id;
 
     const db = await getDb();
     if (!db) {
@@ -45,10 +66,109 @@ export default async function handler(req: Request) {
       system: `You are Flow Guru, a concise voice-first personal assistant.
 Keep responses brief and conversational — they will be spoken aloud.
 Use recallMemory before answering personal questions.
-Use saveMemory when the user shares a fact about themselves (preferences, routine, health, work, hobbies, pets, etc.).`,
+Use saveMemory when the user shares a fact about themselves (preferences, routine, health, work, hobbies, pets, etc.).
+
+DESTINATIONS — Calendar and Lists are SEPARATE.
+
+LISTS (use list_add_item / list_get_items / list_get_all / list_complete_item):
+- Trigger words: "list", "grocery", "groceries", "shopping", "todo", "to-do",
+  "buy", "pick up", "add <item>" without a time.
+- Lists are identified by NAME only (no built-in type/category). Common names:
+  "grocery", "todo", "shopping", "packing".
+- If the user says "my list" without naming one, call list_get_all FIRST and ASK
+  which list. Never guess.
+- list_add_item auto-creates the list if it doesn't exist.
+
+CALENDAR (not yet wired in this endpoint):
+- Trigger words: "calendar", "schedule", "appointment", "meeting",
+  "remind me at <time> <date>", any specific date+time.
+- For now, if the user clearly asks for a calendar event, reply that calendar
+  isn't connected on this endpoint yet. Do NOT silently put it on a list.
+
+NEVER:
+- Put a grocery item on the calendar.
+- Put a timed event on a list.
+- Guess "which list" — call list_get_all and ask.`,
       messages: modelMessages,
       stopWhen: stepCountIs(5),
       tools: {
+        list_get_all: tool({
+          description:
+            "Return all of the user's lists with names. Call this FIRST when the user mentions " +
+            "'my list' without naming which one, then ask which to use. Do not write to lists yet.",
+          inputSchema: z.object({}),
+          execute: async () => {
+            if (!dbUserId) return { error: 'Sign in to use lists.' };
+            const lists = await listUserLists(dbUserId);
+            return { lists: lists.map(l => ({ id: l.id, name: l.name, icon: l.icon })) };
+          },
+        }),
+        list_get_items: tool({
+          description:
+            "Read all items in a named list. Use when the user asks 'what's on my <X> list', " +
+            "'show me my groceries', etc.",
+          inputSchema: z.object({ listName: z.string() }),
+          execute: async ({ listName }) => {
+            if (!dbUserId) return { error: 'Sign in to use lists.' };
+            const list = await findListByName(dbUserId, listName);
+            if (!list) return { error: `No list named "${listName}".` };
+            const items = await getListItems(dbUserId, list.id);
+            return {
+              listName: list.name,
+              items: items.map(i => ({
+                id: i.id,
+                content: i.content,
+                done: i.completed === 1,
+                reminderAt: i.reminderAt,
+                locationTrigger: i.locationTrigger,
+              })),
+            };
+          },
+        }),
+        list_add_item: tool({
+          description:
+            'Add an item to a NAMED list (grocery, todo, shopping, packing, etc.). ' +
+            "If the list doesn't exist yet, this tool creates it. " +
+            'NEVER use this for time-bound calendar events.',
+          inputSchema: z.object({
+            listName: z.string().describe("e.g. 'grocery', 'todo', 'packing'"),
+            item: z.string().describe('the single item or task text'),
+            reminderAtISO: z.string().optional(),
+            locationTrigger: z.string().optional(),
+          }),
+          execute: async ({ listName, item, reminderAtISO, locationTrigger }) => {
+            if (!dbUserId) return { error: 'Sign in to use lists.' };
+            const list = await findListByName(dbUserId, listName);
+            const listId = list ? list.id : await createList(dbUserId, listName);
+            const itemId = await addListItem(dbUserId, listId, item);
+
+            if (reminderAtISO) {
+              const reminderAt = new Date(reminderAtISO);
+              if (!Number.isNaN(reminderAt.getTime())) {
+                await setListItemReminder(dbUserId, itemId, reminderAt);
+              }
+            }
+            if (locationTrigger) {
+              await setListItemLocationTrigger(dbUserId, itemId, locationTrigger);
+            }
+
+            return { ok: true, listName: list?.name ?? listName, itemId };
+          },
+        }),
+        list_complete_item: tool({
+          description: 'Mark an item on a named list as done.',
+          inputSchema: z.object({ listName: z.string(), item: z.string() }),
+          execute: async ({ listName, item }) => {
+            if (!dbUserId) return { error: 'Sign in to use lists.' };
+            const list = await findListByName(dbUserId, listName);
+            if (!list) return { error: `No list named "${listName}".` };
+            const items = await getListItems(dbUserId, list.id);
+            const target = items.find(i => i.content.toLowerCase().includes(item.toLowerCase()));
+            if (!target) return { error: `No item matching "${item}" on "${list.name}".` };
+            await toggleListItem(dbUserId, target.id, true);
+            return { ok: true };
+          },
+        }),
         recallMemory: tool({
           description: 'Recall stored facts about the user',
           inputSchema: z.object({ query: z.string() }),


### PR DESCRIPTION
## Why
Live chat (`useFlowChat → /api/chat`) had no list tools. The LLM was conflating "add to my list" (grocery/todo) with "add to my calendar" (Google Calendar) because `api/chat.ts` only exposed `recallMemory` / `saveMemory`. This wires the existing `fg_lists` / `fg_list_items` schema + `api/lib/db.ts` helpers into the chat tool surface so the assistant can route the two destinations correctly.

## What
Single-file change to `api/chat.ts`:
- `list_get_all` — enumerate the user's lists
- `list_get_items` — read items in a named list
- `list_add_item` — add an item; auto-creates the list if missing; supports optional reminder + location trigger
- `list_complete_item` — mark an item done

System prompt: appended a `DESTINATIONS` block that distinguishes Calendar (time-bound) from Lists (named, no time) and tells the LLM to call `list_get_all` and ASK when the user says "my list" without naming it.

## Reuse
- DB helpers already in `api/lib/db.ts` (lines 685–789): `listUserLists`, `getListItems`, `createList`, `addListItem`, `toggleListItem`, `setListItemReminder`, `setListItemLocationTrigger`
- `openId → fg_users.id` resolution pattern from PR #28 (memory fix)

## Out of scope
- No changes to `assistantActions.ts` (consolidation is a future PR)
- No calendar tools — those live on `wip/googlecal-llm-env`
- No new tables; `fg_lists` has only `name` + `icon` and that's fine

## Verification
- `pnpm build` ✅
- TypeScript check on `api/chat.ts` ✅
- ReadLints on `api/chat.ts` ✅
- `pnpm check` still fails on pre-existing unrelated issues (`web-push`, `Home.tsx`, `Settings.tsx`) — left alone per repo rule
- Anonymous users blocked with `Sign in to use lists.`

## Test matrix (run on Vercel preview, signed in)
| Input | Expected tool | Pass criteria |
|---|---|---|
| "Add milk to my grocery list" | `list_add_item(grocery, milk)` | row in `fg_list_items` |
| "What's on my todo list?" | `list_get_items(todo)` | reads correctly |
| "Add to my list" | `list_get_all` then assistant asks | no write |
| "Remind me to buy bread" | `list_add_item(grocery, bread)` | inferred from "buy" |
| "Schedule dentist Friday 2pm" | no list tool | no list write |
| "Mark milk as done" | `list_complete_item` | `completed=1` |
| Anonymous: "add x to grocery" | error reply | no write |

Made-with: Cursor