### PR TITLE
fix(assistant): list.manage exact-match + blank-name guards

### DIFF
--- a/server/assistantActions.test.ts
+++ b/server/assistantActions.test.ts
@@ -10,6 +10,17 @@ const mapMocks = vi.hoisted(() => ({
 
 const dbMocks = vi.hoisted(() => ({
   getProviderConnection: vi.fn(),
+  listUserLists: vi.fn(),
+  getListItems: vi.fn(),
+  addListItem: vi.fn(),
+  deleteListItem: vi.fn(),
+  toggleListItem: vi.fn(),
+  createList: vi.fn(),
+  deleteList: vi.fn(),
+  updateList: vi.fn(),
+  updateListItem: vi.fn(),
+  setListItemReminder: vi.fn(),
+  setListItemLocationTrigger: vi.fn(),
 }));
 
 const googleCalendarMocks = vi.hoisted(() => ({
@@ -31,6 +42,17 @@ vi.mock("./_core/map", () => ({
 
 vi.mock("./db", () => ({
   getProviderConnection: dbMocks.getProviderConnection,
+  listUserLists: dbMocks.listUserLists,
+  getListItems: dbMocks.getListItems,
+  addListItem: dbMocks.addListItem,
+  deleteListItem: dbMocks.deleteListItem,
+  toggleListItem: dbMocks.toggleListItem,
+  createList: dbMocks.createList,
+  deleteList: dbMocks.deleteList,
+  updateList: dbMocks.updateList,
+  updateListItem: dbMocks.updateListItem,
+  setListItemReminder: dbMocks.setListItemReminder,
+  setListItemLocationTrigger: dbMocks.setListItemLocationTrigger,
 }));
 
 vi.mock("./_core/googleCalendar", () => ({
@@ -48,7 +70,7 @@ describe("assistantActions", () => {
   beforeEach(() => {
     llmMocks.invokeLLM.mockReset();
     mapMocks.makeRequest.mockReset();
-    dbMocks.getProviderConnection.mockReset();
+    Object.values(dbMocks).forEach(mock => mock.mockReset());
     googleCalendarMocks.listGoogleCalendarEvents.mockReset();
     googleCalendarMocks.createGoogleCalendarEvent.mockReset();
     elevenLabsMocks.generateSoundAsDataUri.mockReset();
@@ -717,6 +739,113 @@ describe("assistantActions", () => {
       status: "executed",
       title: "Reminder set: Take meds",
       provider: "google-calendar",
+    });
+  });
+
+  describe("list.manage safety", () => {
+    const listPlan = (list: Record<string, unknown>) => ({
+      action: "list.manage" as const,
+      rationale: "The user wants to manage a list.",
+      route: null,
+      weather: null,
+      news: null,
+      calendar: null,
+      music: null,
+      list,
+      ...NULL_EXTENSIONS,
+    });
+
+    const opts = { userId: 1, timeZone: "America/Toronto" };
+
+    it("prefers an exact list-name match over a substring match", async () => {
+      const { executeAssistantAction } = await import("./assistantActions");
+      dbMocks.listUserLists.mockResolvedValue([
+        { id: 10, name: "grocery weekly" },
+        { id: 11, name: "grocery" },
+      ]);
+      dbMocks.getListItems.mockResolvedValue([]);
+
+      const result = await executeAssistantAction(
+        listPlan({ action: "list", listName: "grocery" }),
+        opts,
+      );
+
+      expect(dbMocks.getListItems).toHaveBeenCalledWith(1, 11);
+      expect(result).toMatchObject({
+        action: "list.manage",
+        status: "executed",
+        data: { listName: "grocery" },
+      });
+    });
+
+    it("removing milk does not match almond milk first", async () => {
+      const { executeAssistantAction } = await import("./assistantActions");
+      dbMocks.listUserLists.mockResolvedValue([{ id: 1, name: "grocery" }]);
+      dbMocks.getListItems
+        .mockResolvedValueOnce([
+          { id: 101, content: "almond milk", completed: 0 },
+          { id: 100, content: "milk", completed: 0 },
+        ])
+        .mockResolvedValueOnce([]);
+      dbMocks.deleteListItem.mockResolvedValue(undefined);
+
+      await executeAssistantAction(
+        listPlan({ action: "remove", listName: "grocery", itemContent: "milk" }),
+        opts,
+      );
+
+      expect(dbMocks.deleteListItem).toHaveBeenCalledWith(1, 100);
+    });
+
+    it("blank itemContent does not match the first row", async () => {
+      const { executeAssistantAction } = await import("./assistantActions");
+      dbMocks.listUserLists.mockResolvedValue([{ id: 1, name: "grocery" }]);
+      dbMocks.getListItems.mockResolvedValue([
+        { id: 100, content: "milk", completed: 0 },
+      ]);
+
+      const result = await executeAssistantAction(
+        listPlan({ action: "remove", listName: "grocery", itemContent: "   " }),
+        opts,
+      );
+
+      expect(result?.status).not.toBe("executed");
+      expect(dbMocks.deleteListItem).not.toHaveBeenCalled();
+    });
+
+    it("blank listName returns needs_input", async () => {
+      const { executeAssistantAction } = await import("./assistantActions");
+
+      const result = await executeAssistantAction(
+        listPlan({ action: "add", listName: "  ", itemContent: "milk" }),
+        opts,
+      );
+
+      expect(result).toMatchObject({
+        action: "list.manage",
+        status: "needs_input",
+      });
+      expect(dbMocks.createList).not.toHaveBeenCalled();
+      expect(dbMocks.addListItem).not.toHaveBeenCalled();
+    });
+
+    it("skips already-completed rows when matching", async () => {
+      const { executeAssistantAction } = await import("./assistantActions");
+      dbMocks.listUserLists.mockResolvedValue([{ id: 1, name: "grocery" }]);
+      dbMocks.getListItems
+        .mockResolvedValueOnce([
+          { id: 99, content: "milk", completed: 1 },
+          { id: 100, content: "milk", completed: 0 },
+        ])
+        .mockResolvedValueOnce([]);
+      dbMocks.deleteListItem.mockResolvedValue(undefined);
+
+      await executeAssistantAction(
+        listPlan({ action: "remove", listName: "grocery", itemContent: "milk" }),
+        opts,
+      );
+
+      expect(dbMocks.deleteListItem).toHaveBeenCalledWith(1, 100);
     });
   });
 });

--- a/server/assistantActions.ts
+++ b/server/assistantActions.ts
@@ -851,7 +851,7 @@ async function executeListAction(plan: AssistantActionPlan, options: { userId: n
   
   // Smarter matching: 
   // 1. Try exact/substring match
-  let targetList = allLists.find(l => l.name.toLowerCase().includes(listName.toLowerCase()));
+  const _lowerListName = listName.trim().toLowerCase(); let targetList = allLists.find(l => l.name.trim().toLowerCase() === _lowerListName) ?? allLists.find(l => l.name.toLowerCase().includes(_lowerListName));
   
   // 2. If listName is very generic (e.g. "list", "my list") and user has lists, pick the most recent one
   const genericNames = ["list", "my list", "smart list", "grocery list", "shopping list"];
@@ -908,7 +908,7 @@ async function executeListAction(plan: AssistantActionPlan, options: { userId: n
           return { action: "list.manage", status: "failed", title: "Cannot remove", summary: `I couldn't find '${itemContent}' on your ${listName} list.` };
         }
         const items = await getListItems(options.userId, targetList.id);
-        const item = items.find(i => i.content.toLowerCase().includes(itemContent.toLowerCase()));
+        const _itemSearch = (itemContent ?? "").trim().toLowerCase(); const item = _itemSearch ? (items.find(i => !i.completed && i.content.trim().toLowerCase() === _itemSearch) ?? items.find(i => !i.completed && i.content.toLowerCase().includes(_itemSearch)) ?? items.find(i => i.content.trim().toLowerCase() === _itemSearch)) : undefined;
         if (!item) {
           return { action: "list.manage", status: "failed", title: "Item not found", summary: `I couldn't find '${itemContent}' in the ${listName} list.` };
         }
@@ -953,7 +953,7 @@ async function executeListAction(plan: AssistantActionPlan, options: { userId: n
           return { action: "list.manage", status: "failed", title: "Cannot update", summary: `I need to know which item to change and what to change it to.` };
         }
         const items = await getListItems(options.userId, targetList.id);
-        const item = items.find(i => i.content.toLowerCase().includes(itemContent.toLowerCase()));
+        const _itemSearch = (itemContent ?? "").trim().toLowerCase(); const item = _itemSearch ? (items.find(i => !i.completed && i.content.trim().toLowerCase() === _itemSearch) ?? items.find(i => !i.completed && i.content.toLowerCase().includes(_itemSearch)) ?? items.find(i => i.content.trim().toLowerCase() === _itemSearch)) : undefined;
         if (!item) {
           return { action: "list.manage", status: "failed", title: "Item not found", summary: `I couldn't find '${itemContent}' in your ${listName} list.` };
         }
@@ -990,7 +990,7 @@ async function executeListAction(plan: AssistantActionPlan, options: { userId: n
         }
         
         const items = await getListItems(options.userId, targetList.id);
-        const item = items.find(i => i.content.toLowerCase().includes(itemContent.toLowerCase()));
+        const _itemSearch = (itemContent ?? "").trim().toLowerCase(); const item = _itemSearch ? (items.find(i => !i.completed && i.content.trim().toLowerCase() === _itemSearch) ?? items.find(i => !i.completed && i.content.toLowerCase().includes(_itemSearch)) ?? items.find(i => i.content.trim().toLowerCase() === _itemSearch)) : undefined;
         if (!item) {
           return { action: "list.manage", status: "failed", title: "Item not found", summary: `I couldn't find '${itemContent}' on your ${listName} list.` };
         }

--- a/server/assistantActions.ts
+++ b/server/assistantActions.ts
@@ -833,7 +833,7 @@ async function executeListAction(plan: AssistantActionPlan, options: { userId: n
   const { action, listName, itemContent, newName, time, location: locationTrigger } = plan.list ?? {};
   console.log(`[DEBUG] executeListAction: userId=${options.userId}, action=${action}, listName=${listName}, itemContent=${itemContent}`);
 
-  if (!action || !listName) {
+  if (!action || !listName?.trim()) {
     return {
       action: "list.manage",
       status: "needs_input",
@@ -849,9 +849,10 @@ async function executeListAction(plan: AssistantActionPlan, options: { userId: n
   
   const allLists = await listUserLists(options.userId);
   
-  // Smarter matching: 
+  // Smarter matching:
   // 1. Try exact/substring match
-  const _lowerListName = listName.trim().toLowerCase(); let targetList = allLists.find(l => l.name.trim().toLowerCase() === _lowerListName) ?? allLists.find(l => l.name.toLowerCase().includes(_lowerListName));
+  const normalizedListName = listName.trim().toLowerCase();
+  let targetList = allLists.find(l => l.name.trim().toLowerCase() === normalizedListName) ?? allLists.find(l => l.name.toLowerCase().includes(normalizedListName));
   
   // 2. If listName is very generic (e.g. "list", "my list") and user has lists, pick the most recent one
   const genericNames = ["list", "my list", "smart list", "grocery list", "shopping list"];


### PR DESCRIPTION
Ports the Codex P2 + Gemini exact-match-first safety fixes into the LIVE tRPC planner (executeListAction in server/assistantActions.ts), where Home.tsx -> trpc.assistant.send actually routes.

PR #29 added these tools to api/chat.ts, but Chat.tsx / useFlowChat is not mounted in client/src/App.tsx, so #29 never ran in production.

Changes:
- targetList lookup: exact (trim+lowercase) match wins over substring includes.
- item lookup in remove/update: prefer incomplete-row exact match, fall back to incomplete-row substring, then any-row exact match. Skips already-completed rows so 'milk' will not re-target 'almond milk'.
- Empty/whitespace itemContent now short-circuits to undefined instead of matching the first row.

Follow-ups:
- Close PR #29 as superseded; api/chat.ts is unmounted dead code.
- Optional cleanup PR: delete api/chat.ts, api/lib/assistantActions.ts (duplicate), Chat.tsx, useFlowChat.
- Run server/assistantActions.test.ts; add cases for milk/almond-milk and blank listName.