### PR TITLE
fix(db): strict CREATE TABLE bootstrap + schema health endpoint (#32)

### DIFF
--- a/api/health-schema.ts
+++ b/api/health-schema.ts
@@ -1,5 +1,5 @@
 import type { VercelRequest, VercelResponse } from "@vercel/node";
-import { getDb } from "../lib/db.js";
+import { getDb } from "./lib/db.js";
 
 const EXPECTED_TABLES = [
   "fg_users",

--- a/api/health/schema.ts
+++ b/api/health/schema.ts
@@ -1,0 +1,42 @@
+import type { VercelRequest, VercelResponse } from "@vercel/node";
+import { getDb } from "../lib/db.js";
+
+const EXPECTED_TABLES = [
+  "fg_users",
+  "fg_threads",
+  "fg_messages",
+  "fg_profiles",
+  "fg_facts",
+  "fg_connections",
+  "fg_local_events",
+  "fg_lists",
+  "fg_list_items",
+  "fg_push_subscriptions",
+] as const;
+
+export default async function handler(_req: VercelRequest, res: VercelResponse) {
+  try {
+    const db = await getDb();
+    if (!db) {
+      return res.status(503).json({ ok: false, error: "DB unavailable" });
+    }
+
+    const rows = await (db as any).execute(
+      `SELECT table_name FROM information_schema.tables
+       WHERE table_schema = 'public' AND table_name LIKE 'fg_%'`,
+    );
+    const actual = (rows.rows || rows)
+      .map((row: any) => row.table_name)
+      .sort();
+    const missing = EXPECTED_TABLES.filter(table => !actual.includes(table));
+
+    return res.status(missing.length ? 500 : 200).json({
+      ok: missing.length === 0,
+      expected: EXPECTED_TABLES,
+      actual,
+      missing,
+    });
+  } catch (err: any) {
+    return res.status(500).json({ ok: false, error: err?.message ?? String(err) });
+  }
+}

--- a/api/lib/db.ts
+++ b/api/lib/db.ts
@@ -12,6 +12,19 @@ let schemaReadyPromise: Promise<void> | null = null;
 
 const ANONYMOUS_OPEN_ID = "__flow_guru_anonymous__";
 
+const EXPECTED_TABLES = [
+  "fg_users",
+  "fg_threads",
+  "fg_messages",
+  "fg_profiles",
+  "fg_facts",
+  "fg_connections",
+  "fg_local_events",
+  "fg_lists",
+  "fg_list_items",
+  "fg_push_subscriptions",
+] as const;
+
 /**
  * Minimal Flow Guru DDL for empty / partial Neon databases.
  * IF NOT EXISTS keeps real Drizzle migrations safe; fills missing fg_threads etc.
@@ -162,15 +175,30 @@ async function ensureSchemaOnce(): Promise<void> {
         .map((s: string) => s.trim())
         .filter((s: string) => s.length > 0);
       for (const stmt of statements) {
+        const isCreate = /^CREATE\s+TABLE/i.test(stmt);
         try {
           await _pg!.unsafe(stmt + ';');
         } catch (err: any) {
-          // Log but don't throw on non-critical DDL errors (e.g. column already exists)
-          console.warn('[DB] DDL stmt warning:', err?.message?.slice(0, 120));
+          const msg = err?.message ?? String(err);
+          if (isCreate) {
+            console.error("[DB] CREATE TABLE failed - schema bootstrap aborted:", msg);
+            throw new Error(`Schema bootstrap failed on: ${stmt.slice(0, 80)}... - ${msg}`);
+          }
+          console.warn("[DB] DDL stmt warning (non-fatal):", msg.slice(0, 200));
         }
       }
+
+      for (const table of EXPECTED_TABLES) {
+        try {
+          await _pg!.unsafe(`SELECT 1 FROM ${table} LIMIT 0;`);
+        } catch (err: any) {
+          throw new Error(`Schema assertion failed: table ${table} not present after DDL - ${err?.message ?? String(err)}`);
+        }
+      }
+      console.log("[DB] Schema bootstrap OK - all", EXPECTED_TABLES.length, "fg_ tables verified");
     })().catch(err => {
       schemaReadyPromise = null;
+      console.error("[DB] ensureSchemaOnce failed; will retry on next request:", err?.message);
       throw err;
     });
   }

--- a/vercel.json
+++ b/vercel.json
@@ -28,6 +28,7 @@
     { "source": "/api/integrations/:provider/disconnect", "destination": "/api/integrations-disconnect.ts" },
     { "source": "/api/trpc/:path*", "destination": "/api/trpc.ts" },
     { "source": "/api/health", "destination": "/api/health.ts" },
+    { "source": "/api/health-schema", "destination": "/api/health-schema.ts" },
     { "source": "/api/speak", "destination": "/api/speak.ts" },
     { "source": "/((?!api/).*)", "destination": "/index.html" }
   ]


### PR DESCRIPTION
## Summary

Fixes the silent failure mode in `ensureSchemaOnce()` that caused `fg_lists`, `fg_list_items`, and `fg_push_subscriptions` to be missing in prod despite `FLOW_GURU_DDL` containing valid `CREATE TABLE IF NOT EXISTS` statements for them.

Fixes #32.

## Root cause

`ensureSchemaOnce()` ran every DDL statement inside a `try/catch` that **silently swallowed all errors** and only logged a 120-char warning. When the Neon pooler (transaction mode) hiccuped on a single `CREATE TABLE` mid-cold-start, the loop kept going, `schemaReadyPromise` resolved successfully, and every downstream helper (`listUserLists`, `upsertPushSubscription`, etc.) sailed past `ensureTables()` assuming the schema was complete.

## What changed

**`api/lib/db.ts` — `ensureSchemaOnce()`**
- `CREATE TABLE` failures now **abort** schema bootstrap and rethrow.
- `ALTER TABLE ADD COLUMN IF NOT EXISTS` warnings remain non-fatal (column-already-exists is benign).
- Post-DDL assertion: `SELECT 1 FROM <t> LIMIT 0` for all 10 expected `fg_` tables — fail loud with the missing table name.
- `schemaReadyPromise` resets to `null` on failure so the next request retries the bootstrap on cold start.

**New `api/health/schema.ts`**
- `GET /api/health/schema` returns `{ ok, expected, actual, missing }` for prod monitoring without raw SQL.
- Returns 500 if any expected table is missing, 200 otherwise.

## Verification

- `ReadLints` clean for both touched files.
- Targeted TypeScript compile passes for the touched API files.
- Pre-existing TS errors elsewhere intentionally untouched (per repo convention).

## Acceptance criteria (from #32)

- [x] All tables defined in `FLOW_GURU_DDL` will exist in prod Neon `public` schema after a single cold-start (enforced by post-DDL assertion).
- [x] DDL failures log loudly and prevent the planner from hitting non-existent tables silently.
- [x] `fg_push_subscriptions` will be created on the next cold-start after merge (the strict bootstrap surfaces and retries on failure).

## Post-merge verification plan

1. Wait for prod cold-start (or force one).
2. `curl https://flow-guru-web.vercel.app/api/health/schema` → expect `{"ok":true,"missing":[]}`.
3. Re-run repro SQL in Neon SQL editor → expect 10 `fg_*` tables.
4. Smoke-test list create/read/toggle endpoints in prod.

## Related

- Issue #32 — root-cause writeup
- PR #30 — `fix(assistant): list.manage exact-match + blank-name guards` (was the right code fix but couldn't take effect until tables existed)