### PR TITLE
fix(assistant): apply list safety to Vercel API path

### DIFF
--- a/api/lib/assistantActions.ts
+++ b/api/lib/assistantActions.ts
@@ -824,7 +824,7 @@ async function executeListAction(plan: AssistantActionPlan, options: { userId: n
   const { action, listName, itemContent, newName, time, location: locationTrigger } = plan.list ?? {};
   console.log(`[DEBUG] executeListAction: userId=${options.userId}, action=${action}, listName=${listName}, itemContent=${itemContent}`);
 
-  if (!action || !listName) {
+  if (!action || !listName?.trim()) {
     return {
       action: "list.manage",
       status: "needs_input",
@@ -840,9 +840,10 @@ async function executeListAction(plan: AssistantActionPlan, options: { userId: n
   
   const allLists = await listUserLists(options.userId);
   
-  // Smarter matching: 
+  // Smarter matching:
   // 1. Try exact/substring match
-  let targetList = allLists.find(l => l.name.toLowerCase().includes(listName.toLowerCase()));
+  const normalizedListName = listName.trim().toLowerCase();
+  let targetList = allLists.find(l => l.name.trim().toLowerCase() === normalizedListName) ?? allLists.find(l => l.name.toLowerCase().includes(normalizedListName));
   
   // 2. If listName is very generic (e.g. "list", "my list") and user has lists, pick the most recent one
   const genericNames = ["list", "my list", "smart list", "grocery list", "shopping list"];
@@ -899,7 +900,14 @@ async function executeListAction(plan: AssistantActionPlan, options: { userId: n
           return { action: "list.manage", status: "failed", title: "Cannot remove", summary: `I couldn't find '${itemContent}' on your ${listName} list.` };
         }
         const items = await getListItems(options.userId, targetList.id);
-        const item = items.find(i => i.content.toLowerCase().includes(itemContent.toLowerCase()));
+        const itemSearch = (itemContent ?? "").trim().toLowerCase();
+        const item = itemSearch
+          ? (
+              items.find(i => !i.completed && i.content.trim().toLowerCase() === itemSearch) ??
+              items.find(i => !i.completed && i.content.toLowerCase().includes(itemSearch)) ??
+              items.find(i => i.content.trim().toLowerCase() === itemSearch)
+            )
+          : undefined;
         if (!item) {
           return { action: "list.manage", status: "failed", title: "Item not found", summary: `I couldn't find '${itemContent}' in the ${listName} list.` };
         }
@@ -944,7 +952,14 @@ async function executeListAction(plan: AssistantActionPlan, options: { userId: n
           return { action: "list.manage", status: "failed", title: "Cannot update", summary: `I need to know which item to change and what to change it to.` };
         }
         const items = await getListItems(options.userId, targetList.id);
-        const item = items.find(i => i.content.toLowerCase().includes(itemContent.toLowerCase()));
+        const itemSearch = (itemContent ?? "").trim().toLowerCase();
+        const item = itemSearch
+          ? (
+              items.find(i => !i.completed && i.content.trim().toLowerCase() === itemSearch) ??
+              items.find(i => !i.completed && i.content.toLowerCase().includes(itemSearch)) ??
+              items.find(i => i.content.trim().toLowerCase() === itemSearch)
+            )
+          : undefined;
         if (!item) {
           return { action: "list.manage", status: "failed", title: "Item not found", summary: `I couldn't find '${itemContent}' in your ${listName} list.` };
         }
@@ -981,7 +996,14 @@ async function executeListAction(plan: AssistantActionPlan, options: { userId: n
         }
         
         const items = await getListItems(options.userId, targetList.id);
-        const item = items.find(i => i.content.toLowerCase().includes(itemContent.toLowerCase()));
+        const itemSearch = (itemContent ?? "").trim().toLowerCase();
+        const item = itemSearch
+          ? (
+              items.find(i => !i.completed && i.content.trim().toLowerCase() === itemSearch) ??
+              items.find(i => !i.completed && i.content.toLowerCase().includes(itemSearch)) ??
+              items.find(i => i.content.trim().toLowerCase() === itemSearch)
+            )
+          : undefined;
         if (!item) {
           return { action: "list.manage", status: "failed", title: "Item not found", summary: `I couldn't find '${itemContent}' on your ${listName} list.` };
         }


### PR DESCRIPTION
## Summary

Mirrors the list safety fixes from PR #30 into the actual prod-served path. PR #30 patched `server/assistantActions.ts` but production `/api/trpc` calls `api/lib/assistantActions.ts` — the duplicate copy was untouched, so the fix never reached prod users.

Discovered while smoke-testing the chat → list write path on prod after PR #33 unblocked the schema layer.

## What changed

`api/lib/assistantActions.ts` — bring up to parity with `server/assistantActions.ts`:
- **Exact list-name matching** (no fuzzy "milk" vs "almond milk" cross-toggling).
- **Blank list-name guard** — reject empty or whitespace-only list names.
- **Item matching safeguards** — same exact-match + blank guards for `addListItem` / `toggleListItem` / `deleteListItem`.

## Verification

- Lints clean for `api/lib/assistantActions.ts`.
- Targeted TypeScript compile passed.
- Pre-existing TS errors in untouched files left alone (per repo convention).

## Post-merge smoke tests on prod

1. Create grocery list → add `milk` → say "I bought almond milk" → expect `milk` to stay incomplete (no fuzzy toggle).
2. Say "complete milk" → expect `milk` toggled complete (exact match still works).
3. Try blank/whitespace list name → expect rejection with clear error.
4. Read back lists → items persist (proves PR #33 schema fix + this routing fix together).

## Follow-up if smoke still fails

If list writes still don't land after this merge, the next suspect is the planner returning `action: "none"` instead of `list.manage`. We'd need the exact chat input/output captured to patch routing.

## Related

- PR #30 — original list.manage fix on the wrong copy
- PR #33 — schema bootstrap fix that unblocked discovery of this gap
- Issue #32 — schema root cause (closed by PR #33)