### PR TITLE
feat(billing): customer portal route (ZYE-16)

### DIFF
--- a/api/billing-portal.ts
+++ b/api/billing-portal.ts
@@ -1,0 +1,97 @@
+import type { VercelRequest, VercelResponse } from "@vercel/node";
+import { sdk } from "./lib/_core/sdk.js";
+import { getSubscriptionStatus } from "./lib/db.js";
+import { captureServerException, initServerSentry } from "./lib/sentry.js";
+
+initServerSentry();
+
+const ACTIVE_STATUSES = new Set(["active", "trialing"]);
+
+function getAppOrigin(req: VercelRequest) {
+  const configured = process.env.INTEGRATION_BROWSER_BASE || process.env.PUBLIC_APP_URL;
+  if (configured) return configured.replace(/\/$/, "");
+  const proto = (req.headers["x-forwarded-proto"] as string | undefined) || "https";
+  const host = req.headers.host;
+  return `${proto}://${host}`;
+}
+
+function getCookieNames(req: VercelRequest) {
+  return (req.headers.cookie ?? "")
+    .split(";")
+    .map(part => part.trim().split("=")[0])
+    .filter(Boolean);
+}
+
+async function createPortalSession(params: {
+  stripeCustomerId: string;
+  origin: string;
+}) {
+  const secret = process.env.STRIPE_SECRET_KEY;
+  if (!secret) {
+    throw new Error("STRIPE_SECRET_KEY is not configured");
+  }
+
+  const body = new URLSearchParams({
+    customer: params.stripeCustomerId,
+    return_url: `${params.origin}/settings?tab=billing`,
+  });
+
+  const response = await fetch("https://api.stripe.com/v1/billing_portal/sessions", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${secret}`,
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body,
+  });
+
+  const payload = await response.json() as { url?: string; error?: { message?: string } };
+  if (!response.ok || !payload.url) {
+    throw new Error(payload.error?.message || "Stripe Billing Portal session failed");
+  }
+
+  return payload.url;
+}
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== "POST") {
+    res.setHeader("Allow", "POST");
+    return res.status(405).json({ error: "Method Not Allowed" });
+  }
+
+  try {
+    const user = await sdk.authenticateRequest(req);
+    const subscription = await getSubscriptionStatus(user.id);
+
+    if (!ACTIVE_STATUSES.has(subscription.status) || !subscription.stripeCustomerId) {
+      return res.status(404).json({
+        error: "No active Flow Guru Monthly subscription found.",
+        code: "SUBSCRIPTION_NOT_FOUND",
+      });
+    }
+
+    const url = await createPortalSession({
+      stripeCustomerId: subscription.stripeCustomerId,
+      origin: getAppOrigin(req),
+    });
+
+    return res.status(200).json({ url });
+  } catch (err: any) {
+    if ((err?.message ?? String(err)).includes("Invalid session cookie")) {
+      captureServerException(err, {
+        tags: { route: "api/billing-portal", kind: "auth" },
+        extra: { cookieNames: getCookieNames(req) },
+      });
+      return res.status(401).json({
+        error: "Please sign in again to manage billing.",
+        code: "AUTH_REQUIRED",
+      });
+    }
+
+    captureServerException(err, {
+      tags: { route: "api/billing-portal" },
+      extra: { method: req.method },
+    });
+    return res.status(500).json({ error: err?.message ?? String(err) });
+  }
+}

--- a/client/src/pages/Settings.tsx
+++ b/client/src/pages/Settings.tsx
@@ -89,6 +89,7 @@ export function Settings() {
   const [billingStatus, setBillingStatus] = useState<any>(null);
   const [billingLoading, setBillingLoading] = useState(false);
   const [checkoutLoading, setCheckoutLoading] = useState(false);
+  const [portalLoading, setPortalLoading] = useState(false);
   const [checkoutError, setCheckoutError] = useState<string | null>(null);
 
   const profileQuery = trpc.settings.getProfile.useQuery(undefined);
@@ -281,6 +282,35 @@ export function Settings() {
       toast.error(err?.message || 'Could not start checkout.');
     } finally {
       setCheckoutLoading(false);
+    }
+  }
+
+  async function handleManageSubscription() {
+    setPortalLoading(true);
+    try {
+      trackConversion('billing_portal_started', {
+        plan: billingStatus?.plan ?? 'pro',
+        status: billingStatus?.status ?? 'unknown',
+      });
+      const response = await fetch('/api/billing/portal', {
+        method: 'POST',
+        credentials: 'include',
+      });
+      const data = await response.json();
+      if (response.status === 401) throw new Error(data.error || 'Please sign in again to manage billing.');
+      if (response.status === 404) throw new Error(data.error || 'No active subscription found.');
+      if (!response.ok || !data.url) throw new Error(data.error || 'Billing portal unavailable.');
+      trackConversion('billing_portal_redirecting', {
+        status: billingStatus?.status ?? 'unknown',
+      });
+      window.location.href = data.url;
+    } catch (err: any) {
+      trackConversion('billing_portal_failed', {
+        reason: err?.message || 'unknown',
+      });
+      toast.error(err?.message || 'Could not open billing portal.');
+    } finally {
+      setPortalLoading(false);
     }
   }
 
@@ -716,17 +746,23 @@ export function Settings() {
                       <li className="flex gap-2"><CheckCircle2 size={13} className="text-primary shrink-0 mt-0.5" />Calendar integrations, voice, and upcoming automation tools</li>
                     </ul>
                     <button
-                      disabled={checkoutLoading || billingStatus?.isPro}
-                      onClick={isBillingUnauthenticated ? () => handleSignInForUpgrade('billing_plan_button') : handleUpgrade}
+                      disabled={checkoutLoading || portalLoading}
+                      onClick={
+                        billingStatus?.isPro
+                          ? handleManageSubscription
+                          : isBillingUnauthenticated
+                            ? () => handleSignInForUpgrade('billing_plan_button')
+                            : handleUpgrade
+                      }
                       className={cn(
                         'w-full flex items-center justify-center gap-2 py-3 rounded-2xl text-sm font-bold transition-all',
                         billingStatus?.isPro
-                          ? 'bg-secondary text-muted-foreground cursor-not-allowed'
+                          ? 'bg-background border border-primary/40 text-primary hover:bg-primary/10'
                           : 'bg-primary text-primary-foreground hover:opacity-90'
                       )}
                     >
-                      {checkoutLoading ? <Loader2 size={14} className="animate-spin" /> : <CreditCard size={14} />}
-                      {billingStatus?.isPro ? 'Current plan' : isBillingUnauthenticated ? 'Sign in to upgrade' : 'Upgrade to Monthly'}
+                      {checkoutLoading || portalLoading ? <Loader2 size={14} className="animate-spin" /> : <CreditCard size={14} />}
+                      {billingStatus?.isPro ? 'Manage subscription' : isBillingUnauthenticated ? 'Sign in to upgrade' : 'Upgrade to Monthly'}
                     </button>
                   </div>
                 </div>

--- a/vercel.json
+++ b/vercel.json
@@ -31,6 +31,7 @@
     { "source": "/api/health-schema", "destination": "/api/health-schema.ts" },
     { "source": "/api/billing/status", "destination": "/api/billing-status.ts" },
     { "source": "/api/billing/checkout", "destination": "/api/stripe-checkout.ts" },
+    { "source": "/api/billing/portal", "destination": "/api/billing-portal.ts" },
     { "source": "/api/stripe/webhook", "destination": "/api/stripe-webhook.ts" },
     { "source": "/api/speak", "destination": "/api/speak.ts" },
     { "source": "/((?!api/).*)", "destination": "/index.html" }


### PR DESCRIPTION
## Summary
Adds a Stripe Billing Portal flow so active subscribers can manage their Flow Guru Monthly plan from Settings → Billing.

Linear: https://linear.app/adgenai/issue/ZYE-16

## Changes
- Adds `api/billing-portal.ts` to create Stripe Billing Portal sessions for authenticated active subscribers.
- Adds `/api/billing/portal` rewrite in `vercel.json`.
- Swaps the Billing tab CTA to `Manage subscription` when `/api/billing/status` reports Pro.
- Returns structured auth/not-found/server errors and captures portal failures with Sentry.

## Screenshots
**Settings → Billing (active subscriber)**
<!-- screenshot -->

**Stripe Billing Portal**
<!-- screenshot -->

**Free-tier state**
<!-- screenshot -->

## Validation
- Focused TS ✅
- Touched-file lints ✅
- Manual preview: Pro account → Manage subscription → Stripe portal redirect